### PR TITLE
Fix handling of deprecated objects (fixes #5)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,7 +8,7 @@
     import { initializeFormats } from "./formats";
 
     const params = new URLSearchParams(window.location.search);
-    let selectedPanel = params.get("view") || "search"; // TODO
+    let selectedPanel = params.get("view") || "search";
 
     onMount(async () => {
         await initializeBookmarks();


### PR DESCRIPTION
Set the deprecated field based on x_mitre_deprecated and revoked fields
in the ATT&CK STIX. This field is already wired to the front-end for
proper display and filtering of deprecated objects.