### PR TITLE
Add missing software objects (fixes #6)

### DIFF
--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -15,12 +15,15 @@ const inputFiles = [
     "data/mobile-attack.json",
 ];
 
+// Note that attack-pattern is handled outside of this map, since it can
+// be a technique or a subtechnique.
 const stixTypeToAttackTypeMap = {
-    "x-mitre-tactic": "tactic",
-    "malware": "software",
     "course-of-action": "mitigation",
     "intrusion-set": "group",
+    "malware": "software",
+    "tool": "software",
     "x-mitre-data-source": "dataSource",
+    "x-mitre-tactic": "tactic",
 };
 
 const mitreSources = {


### PR DESCRIPTION
Software objects can have type "malware" or "tool", and the latter was
not included in the index. This commit adds the "tool" objects so that,
for example, Mimikatz will now appear in search results.