### PR TITLE
Show "open in new tab" in context menu

### DIFF
--- a/src/attack.js
+++ b/src/attack.js
@@ -10,22 +10,39 @@ const attackUrls = {
 }
 
 /**
- * Extract an ATT&CK object ID from text and convert to an ATT&CK URL.
- *
+ * Extract an ATT&CK object ID and it's type (i.e. prefix) from text.
  */
-export function getAttackUrl(text) {
+function getAttackTypeAndId(text) {
     const match = attackRegex.exec(text);
-    var result = null;
-    if (match === null) {
-        result = null;
-    } else {
-        const attackType = match[1].toUpperCase();
-        let attackId = `${match[1]}${match[2]}`;
+    let attackType, attackId = null;
+    if (match !== null) {
+        attackType = match[1].toUpperCase();
+        attackId = `${attackType}${match[2]}`;
         if (match[3]) {
             const subId = match[3].substring(1);
-            attackId = `${attackId}/${subId}`;
+            attackId = `${attackId}.${subId}`;
         }
-        result = attackUrls[attackType].replace("{id}", attackId);
+    }
+    return { attackType, attackId };
+}
+
+/**
+ * Extract an ATT&CK object ID from text.
+ */
+export function getAttackId(text) {
+    const { attackId } = getAttackTypeAndId(text);
+    return attackId;
+}
+
+/**
+ * Extract an ATT&CK object ID from text and convert to an ATT&CK URL.
+ */
+export function getAttackUrl(text) {
+    var result = null;
+    const { attackType, attackId } = getAttackTypeAndId(text);
+    if (attackId !== null) {
+        const attackPath = attackId.replace(".", "/");
+        result = attackUrls[attackType].replace("{id}", attackPath);
     }
     return result;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -4,12 +4,13 @@
  * It monitors the current selection and enables the "Go to selected ATT&CK
  * object" context menu when the selected text looks like an ATT&CK object.
  */
-const attackRegex = /^(TA|T|S|M|G|DS)-?(\d{3,5})$/;
+import { getAttackId } from "./attack.js";
 
 document.addEventListener("selectionchange", function () {
-    var selection = window.getSelection().toString().trim();
+    const selection = window.getSelection().toString();
+    const selectedAttackId = getAttackId(selection);
     chrome.runtime.sendMessage({
-        request: "setAttackLookupEnabled",
-        attackSelected: attackRegex.test(selection),
+        request: "setLookupAttackId",
+        selectedAttackId,
     })
 });

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,8 +13,8 @@ chrome.contextMenus.removeAll();
 
 chrome.contextMenus.create({
     "id": "new-tab",
-    "title": 'Open in new tab',
-    "contexts": ["selection"],
+    "title": 'Open ATT&&CK Powered Suit in new tab',
+    "contexts": ["page", "selection"],
 });
 
 chrome.contextMenus.create({
@@ -25,12 +25,12 @@ chrome.contextMenus.create({
 
 chrome.contextMenus.create({
     "id": "lookup",
-    "title": 'Go to selected ATT&&CK object',
+    "title": 'Go to selected ATT&CK object',
     "contexts": ["selection"],
 });
 
 chrome.contextMenus.onClicked.addListener((info, tab) => {
-    var selection = info.selectionText.trim();
+    var selection = (info.selectionText ?? "").trim();
 
     if (info.menuItemId == "new-tab") {
         const url = chrome.runtime.getURL(`index.html`);
@@ -47,9 +47,21 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 chrome.runtime.onMessage.addListener(
     (message, sender, sendResponse) => {
-        if (message.request == "setAttackLookupEnabled") {
+        if (message.request == "setLookupAttackId") {
+            let title;
+            if (message.selectedAttackId === null) {
+                title = 'Go to selected ATT&CK object';
+            } else {
+                title = `Go to "${message.selectedAttackId}" in ATT&&CK`;
+            }
+            // There's a known race condition where setting the menu title may
+            // not take effect prior to the menu being rendered. This could
+            // lead to undesirable behavior, i.e. the user seeing the wrong
+            // technique ID in the context menu.
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=60758
             chrome.contextMenus.update("lookup", {
-                enabled: message.attackSelected,
+                enabled: message.selectedAttackId !== null,
+                title,
             });
             return true;
         }

--- a/src/worker.js
+++ b/src/worker.js
@@ -25,7 +25,7 @@ chrome.contextMenus.create({
 
 chrome.contextMenus.create({
     "id": "lookup",
-    "title": 'Go to selected ATT&CK object',
+    "title": 'Go to selected ATT&&CK object',
     "contexts": ["selection"],
 });
 
@@ -50,7 +50,7 @@ chrome.runtime.onMessage.addListener(
         if (message.request == "setLookupAttackId") {
             let title;
             if (message.selectedAttackId === null) {
-                title = 'Go to selected ATT&CK object';
+                title = 'Go to selected ATT&&CK object';
             } else {
                 title = `Go to "${message.selectedAttackId}" in ATT&&CK`;
             }

--- a/test/attack.test.js
+++ b/test/attack.test.js
@@ -1,4 +1,4 @@
-import { buildAttackLayer, getAttackUrl } from "../src/attack.js";
+import { buildAttackLayer, getAttackId, getAttackUrl } from "../src/attack.js";
 
 describe("attack.js", () => {
     test("export ATT&CK navigator layer", () => {
@@ -76,6 +76,12 @@ describe("attack.js", () => {
             selectTechniquesAcrossTactics: true,
             selectSubtechniquesWithParent: false,
         });
+    });
+
+    test("extract an ATT&CK ID from text", () => {
+        expect(getAttackId("see the T1548 technique")).toBe("T1548");
+        expect(getAttackId("lsass memory (T1003.001) dump")).toBe("T1003.001");
+        expect(getAttackId("the attacker uses S0002 to dump")).toBe("S0002");
     });
 
     test("convert text to ATT&CK URL", () => {


### PR DESCRIPTION
Previously this item was only shown when text is selected; now it is
shown even when no text is selected.

Also cleaned up the "Go to selected ATT&CK object" menu item--refactored
the code a bit and put the object ID into the menu text so that it's
more transparent about what the menu item will do when you click on it.

Fixes #3
