### PR TITLE
add support for displaying matrices

### DIFF
--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -74,6 +74,9 @@ function extractAttackObject(stixObject) {
                 case "mitre-mobile-attack":
                     attackObject.source_name = "Mobile";
                     break;
+                default:
+                    process.stderr.write(`warning: could not determine the matrix for object:${attackObject.id}\n`);
+                    break;
             }
             break;
         }

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -64,6 +64,17 @@ function extractAttackObject(stixObject) {
         if (reference.source_name in mitreSources) {
             attackObject.id = reference.external_id;
             attackObject.url = reference.url;
+            switch (reference.source_name) {
+                case "mitre-attack":
+                    attackObject.source_name = "Enterprise";
+                    break;
+                case "mitre-ics-attack":
+                    attackObject.source_name = "ICS";
+                    break;
+                case "mitre-mobile-attack":
+                    attackObject.source_name = "Mobile";
+                    break;
+            }
             break;
         }
     }

--- a/src/SearchForm.svelte
+++ b/src/SearchForm.svelte
@@ -46,7 +46,7 @@
                 group: groupsEnabled,
                 deprecated: deprecatedEnabled,
                 Enterprise: enterpriseEnabled,
-                ICS: ICSEnabled,
+                ICS: icsEnabled,
                 Mobile: mobileEnabled,
             });
         }

--- a/src/SearchForm.svelte
+++ b/src/SearchForm.svelte
@@ -97,20 +97,6 @@
             <div class="col">
                 <div class="form-check form-switch">
                     <input
-                        id="techniques"
-                        type="checkbox"
-                        role="switch"
-                        class="form-check-input"
-                        bind:checked={techniquesEnabled}
-                    />
-                    <label for="techniques" class="form-check-label"
-                        >Techniques</label
-                    >
-                </div>
-            </div>
-            <div class="col">
-                <div class="form-check form-switch">
-                    <input
                         id="tactics"
                         type="checkbox"
                         role="switch"
@@ -154,14 +140,14 @@
             <div class="col">
                 <div class="form-check form-switch">
                     <input
-                        id="subtechniques"
+                        id="techniques"
                         type="checkbox"
                         role="switch"
                         class="form-check-input"
-                        bind:checked={subtechniquesEnabled}
+                        bind:checked={techniquesEnabled}
                     />
-                    <label for="subtechniques" class="form-check-label"
-                        >Sub-techniques</label
+                    <label for="techniques" class="form-check-label"
+                        >Techniques</label
                     >
                 </div>
             </div>
@@ -182,6 +168,66 @@
             <div class="col">
                 <div class="form-check form-switch">
                     <input
+                        id="ICS"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={icsEnabled}
+                    />
+                    <label for="mitigations" class="form-check-label">ICS</label
+                    >
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="subtechniques"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={subtechniquesEnabled}
+                    />
+                    <label for="subtechniques" class="form-check-label"
+                        >Sub-techniques</label
+                    >
+                </div>
+            </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="groups"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={groupsEnabled}
+                    />
+                    <label for="groups" class="form-check-label">Groups</label>
+                </div>
+            </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="Mobile"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={mobileEnabled}
+                    />
+                    <label for="mitigations" class="form-check-label"
+                        >Mobile</label
+                    >
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <!-- placeholder so all rows have equal columns -->
+            </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
                         id="dataSources"
                         type="checkbox"
                         role="switch"
@@ -196,36 +242,6 @@
             <div class="col">
                 <div class="form-check form-switch">
                     <input
-                        id="ICS"
-                        type="checkbox"
-                        role="switch"
-                        class="form-check-input"
-                        bind:checked={ICSEnabled}
-                    />
-                    <label for="mitigations" class="form-check-label">ICS</label
-                    >
-                </div>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col">
-                <div class="form-check form-switch">
-                    <input
-                        id="groups"
-                        type="checkbox"
-                        role="switch"
-                        class="form-check-input"
-                        bind:checked={groupsEnabled}
-                    />
-                    <label for="groups" class="form-check-label">Groups</label>
-                </div>
-            </div>
-            <div class="col">
-                <!-- placeholder so all rows have equal columns -->
-            </div>
-            <div class="col">
-                <div class="form-check form-switch">
-                    <input
                         id="deprecated"
                         type="checkbox"
                         role="switch"
@@ -234,20 +250,6 @@
                     />
                     <label for="deprecated" class="form-check-label"
                         >Deprecated</label
-                    >
-                </div>
-            </div>
-            <div class="col">
-                <div class="form-check form-switch">
-                    <input
-                        id="Mobile"
-                        type="checkbox"
-                        role="switch"
-                        class="form-check-input"
-                        bind:checked={mobileEnabled}
-                    />
-                    <label for="mitigations" class="form-check-label"
-                        >Mobile</label
                     >
                 </div>
             </div>

--- a/src/SearchForm.svelte
+++ b/src/SearchForm.svelte
@@ -19,6 +19,9 @@
     let dataSourcesEnabled = true;
     let groupsEnabled = true;
     let deprecatedEnabled = false;
+    let enterpriseEnabled = true;
+    let ICSEnabled = true;
+    let mobileEnabled = true;
 
     onMount(() => {
         initializeSearch().then(() => {
@@ -42,6 +45,9 @@
                 dataSource: dataSourcesEnabled,
                 group: groupsEnabled,
                 deprecated: deprecatedEnabled,
+                Enterprise: enterpriseEnabled,
+                ICS: ICSEnabled,
+                Mobile: mobileEnabled,
             });
         }
     }
@@ -129,6 +135,20 @@
                     >
                 </div>
             </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="Enterprise"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={enterpriseEnabled}
+                    />
+                    <label for="mitigations" class="form-check-label"
+                        >Enterprise</label
+                    >
+                </div>
+            </div>
         </div>
         <div class="row">
             <div class="col">
@@ -173,6 +193,19 @@
                     >
                 </div>
             </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="ICS"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={ICSEnabled}
+                    />
+                    <label for="mitigations" class="form-check-label">ICS</label
+                    >
+                </div>
+            </div>
         </div>
         <div class="row">
             <div class="col">
@@ -201,6 +234,20 @@
                     />
                     <label for="deprecated" class="form-check-label"
                         >Deprecated</label
+                    >
+                </div>
+            </div>
+            <div class="col">
+                <div class="form-check form-switch">
+                    <input
+                        id="Mobile"
+                        type="checkbox"
+                        role="switch"
+                        class="form-check-input"
+                        bind:checked={mobileEnabled}
+                    />
+                    <label for="mitigations" class="form-check-label"
+                        >Mobile</label
                     >
                 </div>
             </div>

--- a/src/SearchForm.svelte
+++ b/src/SearchForm.svelte
@@ -20,7 +20,7 @@
     let groupsEnabled = true;
     let deprecatedEnabled = false;
     let enterpriseEnabled = true;
-    let ICSEnabled = true;
+    let icsEnabled = true;
     let mobileEnabled = true;
 
     onMount(() => {

--- a/src/SearchResults.svelte
+++ b/src/SearchResults.svelte
@@ -27,6 +27,7 @@
                     type: item.type,
                     deprecated: item.deprecated,
                     name: { text: item.name, matches: [] },
+                    source_name: item.source_name,
                     description: { text: item.description, matches: [] },
                     url: item.url,
                     isBookmarked: item.id in $bookmarksSetStore,
@@ -103,6 +104,7 @@
                     matches={result.name.matches}
                 />
             </span>
+            <span class="badge bg-secondary">{result.source_name}</span>
             <span class="badge bg-primary">{result.type}</span>
             {#if result.deprecated}
                 <span class="badge bg-secondary">deprecated</span>

--- a/src/search.js
+++ b/src/search.js
@@ -53,7 +53,8 @@ export function search(query, filters) {
     for (const result of unfilteredResults) {
         const type = result.item.type;
         const deprecated = result.item.deprecated;
-        if (filters[type] === true && (!deprecated || filters.deprecated === true)) {
+        const source = result.item.source_name;
+        if (filters[type] === true && (!deprecated || filters.deprecated === true) && filters[source] === true) {
             if (resultCount < maxResults) {
                 filteredResults.push(result);
             }


### PR DESCRIPTION
Fixes #11 

## What Changed

* Now displays the matrix (Enterprise, ICS, or Mobile) of items in the search results
* Adds search filters to allow filtering by matrix

### Screenshot
<img width="604" alt="ATT CK Powered Suit 2022-09-02 09-05-16" src="https://user-images.githubusercontent.com/6472686/188166752-51b4b6a3-2805-4e46-88f6-bcd72f6324aa.png">


## Limitations

* Adding the extra column of search filters does impact the alignment/wrapping of other search filters which does look a tiny bit less pleasing.
  * This could be mitigated by adding an extra row but that has its own side effects.
* Although not introduced by the PR nor in scope for this issue, the extension does not "remember" the state of which search filters are enabled/disabled. 
