### PR TITLE
extract matrix type from x_mitre_domains

### DIFF
--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -64,23 +64,28 @@ function extractAttackObject(stixObject) {
         if (reference.source_name in mitreSources) {
             attackObject.id = reference.external_id;
             attackObject.url = reference.url;
-            switch (reference.source_name) {
-                case "mitre-attack":
-                    attackObject.source_name = "Enterprise";
-                    break;
-                case "mitre-ics-attack":
-                    attackObject.source_name = "ICS";
-                    break;
-                case "mitre-mobile-attack":
-                    attackObject.source_name = "Mobile";
-                    break;
-                default:
-                    process.stderr.write(`warning: could not determine the matrix for object:${attackObject.id}\n`);
-                    break;
-            }
             break;
         }
     }
+
+    // extract the ATT&CK matrix from the STIX object
+    for (const mitreDomain of stixObject.x_mitre_domains) {
+        switch (mitreDomain) {
+            case "enterprise-attack":
+                attackObject.is_enterprise = true;
+                break;
+            case "ics-attack":
+                attackObject.is_ics = true;
+                break;
+            case "mobile-attack":
+                attackObject.is_mobile = true;
+                break;
+            default:
+                process.stderr.write(`warning: could not determine the matrix for object:${attackObject.id}\n`);
+                break;
+        }
+    }
+
 
     if (!("id" in attackObject)) {
         console.log(stixObject);

--- a/src/SearchResults.svelte
+++ b/src/SearchResults.svelte
@@ -31,6 +31,9 @@
                     description: { text: item.description, matches: [] },
                     url: item.url,
                     isBookmarked: item.id in $bookmarksSetStore,
+                    is_enterprise: item.is_enterprise,
+                    is_ics: item.is_ics,
+                    is_mobile: item.is_mobile,
                 };
                 for (const match of matches) {
                     const { key, indices } = match;
@@ -104,7 +107,15 @@
                     matches={result.name.matches}
                 />
             </span>
-            <span class="badge bg-secondary">{result.source_name}</span>
+            {#if result.is_enterprise}
+                <span class="badge bg-secondary">Enterprise</span>
+            {/if}
+            {#if result.is_mobile}
+                <span class="badge bg-secondary">Mobile</span>
+            {/if}
+            {#if result.is_ics}
+                <span class="badge bg-secondary">ICS</span>
+            {/if}
             <span class="badge bg-primary">{result.type}</span>
             {#if result.deprecated}
                 <span class="badge bg-secondary">deprecated</span>

--- a/src/search.js
+++ b/src/search.js
@@ -53,12 +53,13 @@ export function search(query, filters) {
     for (const result of unfilteredResults) {
         const type = result.item.type;
         const deprecated = result.item.deprecated;
-        const source = result.item.source_name;
-        if (filters[type] === true && (!deprecated || filters.deprecated === true) && filters[source] === true) {
-            if (resultCount < maxResults) {
-                filteredResults.push(result);
+        if (filters[type] === true && (!deprecated || filters.deprecated === true)) {
+            if (filters["ICS"] == result.item.is_ics || filters["Mobile"] == result.item.is_mobile || filters["Enterprise"] == result.item.is_enterprise) {
+                if (resultCount < maxResults) {
+                    filteredResults.push(result);
+                }
+                resultCount++;
             }
-            resultCount++;
         }
     }
 


### PR DESCRIPTION
Fixes #21 

## What Changed

* extract the associated matrix for objects from `x_mitre_domains` instead of the reference `source_name`
* add support for displaying multiple badges if an object belongs to multiple matrices

### Screenshot Demo 
<img width="575" alt="ATT CK 2022-09-26 08-22-26" src="https://user-images.githubusercontent.com/6472686/192875286-1631a794-3a6f-4cb1-915b-709ccdfa5f0a.png">


## Limitations

* While implementing this PR I discovered that the `x_mitre_domains` value is not consistent across the JSON files. Just to pick on an example from the issue, G0088 is tagged as only enterprise-attack in `enterprise-attack.json` but is tagged as both enterprise-attack and ics-attack in `ics-attack.json`. And since `enterprise-attack.json` is the file that is processed first and each object is only processed once, that results in many objects which belong to multiple matrices only being tagged as enterprise. 
	* It looks like this discrepancy is originating from [mitre-attack/attack-stix-data](https://github.com/mitre-attack/attack-stix-data). An easy but hacky solution would be change the ordering of the JSON files we ingest since `ics-attack.json` and `mobile-attack.json` generally seem to be more accurately tagged.
