### PR TITLE
Make search form automatically focus cursor

### DIFF
--- a/src/SearchForm.svelte
+++ b/src/SearchForm.svelte
@@ -67,12 +67,14 @@
 <form on:submit={(e) => e.preventDefault()}>
     <div class="search-row">
         <div class="form-floating">
+            <!-- svelte-ignore a11y-autofocus -->
             <input
                 id="searchTerms"
                 type="text"
                 class="form-control"
                 placeholder="Search ATT&amp;CK…"
                 bind:value={query}
+                autofocus
             />
             <label for="searchTerms">Search ATT&amp;CK…</label>
         </div>


### PR DESCRIPTION
Fixes #24 

## What Changed

* Implements a fix for #24 by adding `autofocus` to the primary search input.  

## Limitations

This introduces a new linter warning, see below. I ignored the warning because it sounds like there is some disagreement on the validity of it with the exception of some use cases [^1].

```sh
src/main.js → public/build/bundle.js...
(!) Plugin svelte: A11y: Avoid using autofocus
src/SearchForm.svelte
74:                 placeholder="Search ATT&amp;CK…"
75:                 bind:value={query}
76:                 autofocus
                    ^
77:             />
78:             <label for="searchTerms">Search ATT&amp;CK…</label>
created public/build/bundle.js in 4.9s
```

[^1]: https://github.com/sveltejs/svelte/issues/6629
