### PR TITLE
Add parent technique to search results (fixes #41)

### DIFF
--- a/src/SearchResults.svelte
+++ b/src/SearchResults.svelte
@@ -29,6 +29,7 @@
                     type: result.type,
                     deprecated: result.deprecated,
                     name: { text: result.name, matches: [] },
+                    parentName: { text: result.parentName, matches: [] },
                     source_name: result.source_name,
                     description: { text: result.description, matches: [] },
                     url: result.url,
@@ -54,6 +55,7 @@
                 const sortMatches = (a, b) => a[0] - b[0];
                 highlightedResult.id.matches.sort(sortMatches);
                 highlightedResult.name.matches.sort(sortMatches);
+                highlightedResult.parentName.matches.sort(sortMatches);
                 highlightedResult.description.matches.sort(sortMatches);
                 highlightedResults.push(highlightedResult);
             }
@@ -120,8 +122,16 @@
                 <HighlightMatches
                     text={result.id.text}
                     matches={result.id.matches}
-                />:
+                />
             </span>
+            {#if result.parentName}
+                <span class="result-name">
+                    <HighlightMatches
+                        text={result.parentName.text}
+                        matches={result.parentName.matches}
+                    />:
+                </span>
+            {/if}
             <span class="result-name">
                 <HighlightMatches
                     text={result.name.text}

--- a/src/SettingsPanel.svelte
+++ b/src/SettingsPanel.svelte
@@ -25,7 +25,8 @@
     You can add custom formats that copy snippets from search results. The
     following variables names can be used inside curly braces: <code
         >{"{description}"}</code
-    >, <code>{"{name}"}</code>,
+    >, <code>{"{name}"}</code>, <code>{"{fullName}"}</code>,
+    <code>{"{parentName}"}</code>,
     <code>{"{id}"}</code>, <code>{"{type}"}</code>, <code>{"{url}"}</code>,
     <code>{"{stixId}"}</code>
 </div>
@@ -65,7 +66,7 @@
                         />
                     </td>
                     <td>
-                        <input 
+                        <input
                             readonly="readonly"
                             type="text"
                             class="form-control"

--- a/src/formats.js
+++ b/src/formats.js
@@ -21,6 +21,8 @@ export function formatObject(format, object) {
         .replace("{description}", object.description.text)
         .replace("{id}", object.id.text)
         .replace("{name}", object.name.text)
+        .replace("{fullName}", object.parentName.text ? `${object.parentName.text}: ${object.name.text}` : object.name.text)
+        .replace("{parentName}", object.parentName.text ?? "")
         .replace("{type}", object.type)
         .replace("{stixId}", object.stixId)
         .replace("{url}", object.url);
@@ -35,11 +37,11 @@ export function initializeFormats() {
 
         // Set up initial formats if none found.
         if (formats.length === 0) {
-            addFormat("Name", "{name}", "text/plain");
-            addFormat("Summary", "{id} ({type}): {name} – {description}", "text/plain");
+            addFormat("Name", "{fullName}", "text/plain");
+            addFormat("Summary", "{id} ({type}): {fullName} – {description}", "text/plain");
 
             if (supportsClipboardItem()) {
-                addFormat("Link", '<a href="{url}">{id}: {name}</a>', "text/html");
+                addFormat("Link", '<a href="{url}">{id}: {fullName}</a>', "text/html");
             } else {
                 addFormat("Link", "{url}", "text/plain")
             }

--- a/src/search.js
+++ b/src/search.js
@@ -7,10 +7,11 @@ import lunr from 'lunr';
  */
 export const lunrOptions = function () {
     this.ref("lunrRef");
-    this.field("id", { boost: 3 });
+    this.field("id", { boost: 4 });
     this.field("stixId");
     this.field("type");
-    this.field("name", { boost: 2 });
+    this.field("name", { boost: 3 });
+    this.field("parentName", { boost: 2 });
     this.field("description", { boost: 1 });
     this.field("url");
     this.field("is_enterprise");

--- a/test/formats.test.js
+++ b/test/formats.test.js
@@ -43,19 +43,19 @@ describe("formats.js", () => {
                 "id": 0,
                 "mime": "text/plain",
                 "name": "Name",
-                "rule": "{name}",
+                "rule": "{fullName}",
             },
             {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,
                 "mime": "text/html",
                 "name": "Link",
-                "rule": "<a href=\"{url}\">{id}: {name}</a>",
+                "rule": "<a href=\"{url}\">{id}: {fullName}</a>",
             },
         ]);
 
@@ -65,13 +65,13 @@ describe("formats.js", () => {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,
                 "mime": "text/html",
                 "name": "Link",
-                "rule": "<a href=\"{url}\">{id}: {name}</a>",
+                "rule": "<a href=\"{url}\">{id}: {fullName}</a>",
             },
         ]);
 
@@ -81,13 +81,13 @@ describe("formats.js", () => {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,
                 "mime": "text/html",
                 "name": "Link",
-                "rule": "<a href=\"{url}\">{id}: {name}</a>",
+                "rule": "<a href=\"{url}\">{id}: {fullName}</a>",
             },
             {
                 "id": 3,
@@ -109,13 +109,13 @@ describe("formats.js", () => {
                 "id": 0,
                 "mime": "text/plain",
                 "name": "Name",
-                "rule": "{name}",
+                "rule": "{fullName}",
             },
             {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,
@@ -131,7 +131,7 @@ describe("formats.js", () => {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,
@@ -147,7 +147,7 @@ describe("formats.js", () => {
                 "id": 1,
                 "mime": "text/plain",
                 "name": "Summary",
-                "rule": "{id} ({type}): {name} – {description}",
+                "rule": "{id} ({type}): {fullName} – {description}",
             },
             {
                 "id": 2,


### PR DESCRIPTION
As discussed in the other PR for this issue (see #42), this implementation ensures the parent name is handled correctly with respect to highlighting and search result ranking.