### PR TITLE
Initialize bookmark preference (fixes #38)

### DIFF
--- a/src/bookmarks.js
+++ b/src/bookmarks.js
@@ -24,9 +24,9 @@ export let bookmarksColorByStore = writable("Color");
  * Initialize bookmarks.
  */
 export async function initializeBookmarks() {
-    bookmarks = await loadFromStorage("bookmarks");
+    bookmarks = await loadFromStorage("bookmarks") ?? [];
     bookmarksStore.set(bookmarks);
-    const bookmarksColorBy = await loadFromStorage("bookmarks_color_by");
+    const bookmarksColorBy = await loadFromStorage("bookmarks_color_by") ?? "Color";
     bookmarksColorByStore.set(bookmarksColorBy);
 
     // Create bookmarks set
@@ -45,7 +45,7 @@ export async function initializeBookmarks() {
  * @param {string} notes - used for exporting ATT&CK layer
  * @param {string} color - used for exporting ATT&CK layer
  */
-export function addBookmark(id, name, score = 0, notes = "", color = "#000000") {
+export function addBookmark(id, name, score = 0, notes = "", color = "#f54d4d") {
     // Update bookmarks array
     bookmarks.push({
         id: id,

--- a/src/storage.js
+++ b/src/storage.js
@@ -39,9 +39,9 @@ export function saveToStorage(key, value, debounce = 500) {
  * storage backend.
  *
  * @param {string} key
- * @returns {object} - the stored object or null if the key doesn't exist
+ * @returns {object} - the stored object or null if it doesn't exist
  */
-export async function loadFromStorage(key) {
+export async function loadFromStorage(key, defaultValue) {
     let storedData = null;
     if (window.chrome && window.chrome.storage) {
         const storageResult = await window.chrome.storage.sync.get({ [key]: [] });
@@ -51,10 +51,7 @@ export async function loadFromStorage(key) {
     } else if (localStorage) {
         const storedDataJson = localStorage.getItem(key);
         try {
-            if (storedDataJson == null) {
-                storedData = []
-            }
-            else {
+            if (storedDataJson !== null) {
                 storedData = JSON.parse(storedDataJson);
             }
         } catch (e) {


### PR DESCRIPTION
On new install, the bookmark preference is now initialized to "Color" as in to shade the exported navigator layers using a color picker. I also picked a new default for the color to match what ATT&CK navigator uses when the score is set to zero.