### PR TITLE
APS-9: Render ATT&CK Markdown and Citations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "marked": "^4.0.12",
         "rollup-jest": "^1.1.3",
         "rollup-plugin-copy": "^3.4.0",
+        "sanitize-html": "^2.13.0",
         "sirv-cli": "^2.0.0"
       },
       "devDependencies": {
@@ -2414,9 +2415,9 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "funding": [
         {
           "type": "github",
@@ -5228,6 +5229,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5396,6 +5414,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -5451,9 +5474,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -5483,6 +5506,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pre-commit": {
@@ -6004,6 +6054,107 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-html": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -6128,6 +6279,14 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-resolve": {
@@ -8555,9 +8714,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -10601,6 +10760,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10723,6 +10887,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -10763,9 +10932,9 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -10783,6 +10952,16 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postcss": {
+      "version": "8.4.41",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
+      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "requires": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
       }
     },
     "pre-commit": {
@@ -11163,6 +11342,75 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize-html": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "htmlparser2": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -11255,6 +11503,11 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+    },
+    "source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "source-map-resolve": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "marked": "^4.0.12",
     "rollup-jest": "^1.1.3",
     "rollup-plugin-copy": "^3.4.0",
+    "sanitize-html": "^2.13.0",
     "sirv-cli": "^2.0.0"
   },
   "jest": {

--- a/src/HighlightMatches.svelte
+++ b/src/HighlightMatches.svelte
@@ -1,119 +1,138 @@
 <script>
-    const FROM_RIGHT = true;
-    const FROM_LEFT = false;
+    import sanitizeHtml from 'sanitize-html';
+
     export let text;
-    export let matches;
+    export let highlights;
     export let maxLength = null;
 
-    // Trim a string to a specified length.
-    //
-    // If fromRight is true, start at the right end and move left to find the
-    // appropriate length. Otherwise start at the left end and move right. Add ellipses
-    // as appropriate.
-    function snippet(str, length, direction = FROM_RIGHT) {
-        let snip;
-        if (str.length > length) {
-            if (direction == FROM_RIGHT) {
-                // Scan right from the length to the first space (or end of string if
-                // no more spaces.
-                let idx = length + 1;
-                while (idx < str.length && str.charAt(idx) != " ") {
-                    idx++;
-                }
-                snip = str.substring(0, idx) + "…";
-            } else {
-                // Scan left from the starting point to the first space (or end of
-                // string if no more spaces.
-                let idx = str.length - length;
-                while (idx >= 0 && str.charAt(idx) != " ") {
-                    idx--;
-                }
-                snip = "…" + str.substring(idx);
-            }
-        } else {
-            snip = str;
+    /**
+     * Highlights the specified regions of text.
+     * @param text
+     *  The text to highlight.
+     * @param highlights
+     *  The highlight regions (in ascending order).
+     * @returns
+     *  The highlighted text.
+     */
+    function highlight(text, highlights) {
+        if(text === null || text === "") {
+            return "";
         }
-        return [snip, str.length - snip.length];
+        let base = 0;
+        let highlightedText = "";
+        for(let i = 0; i < highlights.length; i++) {
+            const h = highlights[i];
+            highlightedText += text.slice(base, h[0]);
+            highlightedText += `<mark>${text.slice(h[0], h[1])}</mark>`;
+            base = h[1];
+        }
+        return highlightedText + text.slice(base, text.length);
     }
 
-    let segments;
-    $: {
-        // Process the text into a series of alternating segments. Each odd-numbered
-        // index is highlighted and each even-numbered index is not.
-        segments = [];
-        let lowIdx = 0;
-        for (const match of matches) {
-            const unhighlighted = text.substring(lowIdx, match[0]);
-            segments.push(unhighlighted);
-            const highlighted = text.substring(match[0], match[1]);
-            segments.push(highlighted);
-            lowIdx = match[1];
+    /**
+     * Cuts out a snippet of text surrounding the first chunk of highlighted
+     * text. (Highlighted text is any text encapsulated in a <mark> tag.)
+     * @param text
+     *  The text to cut from.
+     * @param length
+     *  The length of the snippet (not including HTML tags).
+     */
+    function cutOutHighlightedSnippet(text, length) {
+        if(length === null) {
+            // If no length, return text as is
+            return text;
         }
-
-        // The previous section leaves the text to the right of the last highlight
-        // unprocessed, so we pull that in here.
-        const lastSegment = text ? text.substring(lowIdx) : "";
-        if (lastSegment.length > 0) {
-            segments.push(lastSegment);
+        const emptyTags = /<\s*?([a-zA-Z0-9]+)[^<>]*><\/\s*?([a-zA-Z0-9]+)\s*>/;
+        // Tokenize text
+        const tokens = text.split(/(<.*?>)/);
+        // Select focal token
+        const focalToken = tokens.indexOf("<mark>") + 1;
+        if(focalToken === 0) {
+            // If no highlight, return text as is
+            return text;
         }
-
-        // Now enforce the maxLength constraint.
-        if (maxLength) {
-            // Two basic approaches here:
-            if (segments.length == 1) {
-                // If there is only 1 segment, then there are no highlights and we can
-                // just trim the right side of the segment.
-                const [snip, removed] = snippet(
-                    segments[0],
-                    maxLength,
-                    FROM_RIGHT
-                );
-                segments[0] = snip;
-            } else {
-                let totalLength = segments.reduce(
-                    (total, segment) => total + segment.length,
-                    0
-                );
-
-                // If there are multiple segments, start by snipping the first segment.
-                const firstSnipLength = Math.ceil(maxLength / 2);
-                const [snip0, snip0Removed] = snippet(
-                    segments[0],
-                    firstSnipLength,
-                    FROM_LEFT
-                );
-                segments[0] = snip0;
-                totalLength -= snip0Removed;
-
-                // Now pop segments off the end to get under the maxLength, but keep at
-                // least 2 segments (so we keep at least one highlighted).
-                let segment = null;
-                while (totalLength > maxLength && segments.length > 2) {
-                    segment = segments.pop();
-                    totalLength -= segment.length;
-                }
-
-                // Now add however many remaining characters we have from the last
-                // popped segment.
-                if (segment !== null) {
-                    const [snip, removed] = snippet(
-                        segment,
-                        maxLength - totalLength,
-                        FROM_RIGHT
-                    );
-                    segments.push(snip);
-                }
+        // Recalculate max length
+        length -= tokens[focalToken].length;
+        if (length <= 0) {
+            return tokens.slice(focalToken - 1, focalToken + 2).join();
+        }
+        // Find length of text on each side of focal token
+        let l_len = 0, r_len = 0;
+        for(let i = 0; i < tokens.length; i += 2) {
+            if(i < focalToken) {
+                l_len += tokens[i].length;
+            }
+            if(focalToken < i) {
+                r_len += tokens[i].length;
             }
         }
+        // Trim ends
+        const swap = l_len <= r_len ? 0 : 1; 
+        for(let i = 0, extraExtent = 0; i < 2; i++) {
+            if(((i + swap) % 2) === 0) {
+                // Trim beginning
+                let extent = Math.ceil(length / 2) + extraExtent;
+                for (let i = focalToken - 2; 0 <= i; i -= 2) {
+                    let clip = tokens[i];
+                    if (extent === 0) {
+                        tokens[i] = "";
+                    } else if (clip.length <= extent) {
+                        extent -= clip.length;
+                    } else {
+                        let j = clip.length - extent;
+                        while (0 <= j && clip[j].match(/\S/)) {
+                            j--;
+                        }
+                        extent = 0;
+                        tokens[i] = `...${clip.slice(j + 1)}`;
+                    }
+                }
+                extraExtent += extent;
+            } else {
+                // Trim end
+                let extent = Math.floor(length / 2) + extraExtent;
+                for (let i = focalToken + 2; i < tokens.length; i += 2) {
+                    let clip = tokens[i];
+                    if (extent === 0) {
+                        tokens[i] = "";
+                    } else if (clip.length <= extent) {
+                        extent -= clip.length;
+                    } else {
+                        let j = extent;
+                        while (j < clip.length && clip[j].match(/\S/)) {
+                            j++;
+                        }
+                        extent = 0;
+                        tokens[i] = `${clip.slice(0, j)}...`;
+                    }
+                }
+                extraExtent += extent;
+            }
+        }
+        // Filter empty HTML tags
+        let trimmedText = tokens.join("");
+        while (emptyTags.test(trimmedText)) {
+            trimmedText = trimmedText.replace(
+                emptyTags,
+                (str, begTag, endTag) => {
+                    if (begTag === endTag) {
+                        return "";
+                    } else {
+                        return str;
+                    }
+                }
+            )
+        }
+        return trimmedText;
     }
 </script>
 
-{#each segments as segment, index}
-    <span class:highlight={index % 2 == 1}>{segment}</span>
-{/each}
+<span class="markdown">{@html 
+    sanitizeHtml(cutOutHighlightedSnippet(highlight(text, highlights), maxLength))
+}</span>
 
 <style>
-    .highlight {
+    :global(mark) {
         color: var(--me-ext-orange-dark);
     }
 </style>

--- a/src/HighlightMatches.svelte
+++ b/src/HighlightMatches.svelte
@@ -84,7 +84,7 @@
                             j--;
                         }
                         extent = 0;
-                        tokens[i] = `...${clip.slice(j + 1)}`;
+                        tokens[i] = `…${clip.slice(j + 1)}`;
                     }
                 }
                 extraExtent += extent;
@@ -103,7 +103,7 @@
                             j++;
                         }
                         extent = 0;
-                        tokens[i] = `${clip.slice(0, j)}...`;
+                        tokens[i] = `${clip.slice(0, j)}…`;
                     }
                 }
                 extraExtent += extent;

--- a/src/formats.js
+++ b/src/formats.js
@@ -29,6 +29,17 @@ export function formatObject(format, object) {
 }
 
 /**
+ * Given an HTML string, return the same string as plaintext.
+ * @param {*} text
+ *  The HTML to format.
+ * @returns
+ *  The HTML formatted as plaintext.
+ */
+export function formatHtmlAsPlaintext(text) {
+    return new DOMParser().parseFromString(text, 'text/html').body.innerText;
+}
+
+/**
  * Initialize formats.
  */
 export function initializeFormats() {


### PR DESCRIPTION
Fixes #9

## What Changed
Search results now properly render ATT&CK Markdown and referenced citations. This PR also addresses a bug that caused text snippets to be cut inconsistently.

<img width="634" alt="image" src="https://github.com/user-attachments/assets/f97777a7-468c-445c-9988-15aca1568f19">

## Known Limitations
None