### PR TITLE
APS-10: Fix Crushed Window on Firefox 128.0

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -10,6 +10,7 @@ body {
     margin: 0 auto;
     min-width: 600px;
     max-width: 800px;
+    min-height: 393px;
     padding: 1rem;
     box-sizing: border-box;
     font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;


### PR DESCRIPTION
Fixes #10

## What Changed
Addresses bug which crushed extension popup in Firefox 128.0.

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/969ba284-0077-448b-be62-f329c10c069d">

## Known Limitations
None